### PR TITLE
Add a way to set run loop mode

### DIFF
--- a/UIImageView-PlayGIF/UIImageView-PlayGIF/UIImageView+PlayGIF.h
+++ b/UIImageView-PlayGIF/UIImageView-PlayGIF/UIImageView+PlayGIF.h
@@ -47,6 +47,7 @@
 @property (nonatomic, strong) NSData            *gifData;
 @property (nonatomic, strong) NSNumber          *index,*frameCount,*timestamp;
 - (void)startGIF;
+- (void)startGIFwithRunLoopMode:(NSString * const)runLoopMode;
 - (void)stopGIF;
 - (BOOL)isGIFPlaying;
 @end

--- a/UIImageView-PlayGIF/UIImageView-PlayGIF/UIImageView+PlayGIF.m
+++ b/UIImageView-PlayGIF/UIImageView-PlayGIF/UIImageView+PlayGIF.m
@@ -132,7 +132,13 @@ static const char * kTimestampKey       = "kTimestampKey";
 
 #pragma mark - ACTIONS
 
-- (void)startGIF{
+- (void)startGIF
+{
+    [self startGIFwithRunLoopMode:NSDefaultRunLoopMode];
+}
+
+- (void)startGIFwithRunLoopMode:(NSString * const)runLoopMode
+{
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
         if (![[PlayGIFManager shared].gifViewHashTable containsObject:self] && (self.gifData || self.gifPath)) {
             CGImageSourceRef gifSourceRef;
@@ -153,7 +159,7 @@ static const char * kTimestampKey       = "kTimestampKey";
     });
     if (![PlayGIFManager shared].displayLink) {
         [PlayGIFManager shared].displayLink = [CADisplayLink displayLinkWithTarget:[PlayGIFManager shared] selector:@selector(play)];
-        [[PlayGIFManager shared].displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+        [[PlayGIFManager shared].displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:runLoopMode];
     }
 }
 

--- a/UIImageView-PlayGIF/UIImageView-PlayGIF/YFGIFImageView.h
+++ b/UIImageView-PlayGIF/UIImageView-PlayGIF/YFGIFImageView.h
@@ -46,6 +46,7 @@
 @property (nonatomic, strong) NSString          *gifPath;
 @property (nonatomic, strong) NSData            *gifData;
 - (void)startGIF;
+- (void)startGIFwithRunLoopMode:(NSString * const)runLoopMode;
 - (void)stopGIF;
 - (BOOL)isGIFPlaying;
 @end

--- a/UIImageView-PlayGIF/UIImageView-PlayGIF/YFGIFImageView.m
+++ b/UIImageView-PlayGIF/UIImageView-PlayGIF/YFGIFImageView.m
@@ -68,7 +68,13 @@
     [self stopGIF];
 }
 
-- (void)startGIF{
+- (void)startGIF
+{
+    [self startGIFwithRunLoopMode:NSDefaultRunLoopMode];
+}
+
+- (void)startGIFwithRunLoopMode:(NSString * const)runLoopMode
+{
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
         if (![[YFGIFManager shared].gifViewHashTable containsObject:self]) {
             if ((self.gifData || self.gifPath)) {
@@ -91,7 +97,7 @@
     });
     if (![YFGIFManager shared].displayLink) {
         [YFGIFManager shared].displayLink = [CADisplayLink displayLinkWithTarget:[YFGIFManager shared] selector:@selector(play)];
-        [[YFGIFManager shared].displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:NSDefaultRunLoopMode];
+        [[YFGIFManager shared].displayLink addToRunLoop:[NSRunLoop mainRunLoop] forMode:runLoopMode];
     }
 }
 


### PR DESCRIPTION
Hello, thanks for creating this useful library. I love it much.

But I've noticed that GIF animation playback is deferred until scroll stops when used inside UITableView. The issue could be easily mitigated by changing CADisplayLink's run loop mode for `NSRunLoopCommonModes`, so I've added a way to pass run loop mode to `startGIF`.

Any feedback will be greatly appreciated!
