### PR TITLE
Ensured UIImageView is defined to avoid swift compilation issue.

### DIFF
--- a/UIImageView-PlayGIF/UIImageView-PlayGIF/UIImageView+PlayGIF.h
+++ b/UIImageView-PlayGIF/UIImageView-PlayGIF/UIImageView+PlayGIF.h
@@ -38,6 +38,8 @@
  *      不想用 category？请使用 YFGIFImageView.h/m
  *******************************************************/
 
+#import <UIKit/UIImageView.h>
+
 @interface UIImageView (PlayGIF)
 @property (nonatomic, strong) NSString          *gifPath;
 @property (nonatomic, strong) NSData            *gifData;

--- a/UIImageView-PlayGIF/UIImageView-PlayGIF/YFGIFImageView.h
+++ b/UIImageView-PlayGIF/UIImageView-PlayGIF/YFGIFImageView.h
@@ -38,6 +38,8 @@
  *      想用 category？请使用 UIImageView+PlayGIF.h/m
  *******************************************************/
 
+#import <UIKit/UIImageView.h>
+
 @interface YFGIFImageView : UIImageView
 @property (nonatomic, strong) NSString          *gifPath;
 @property (nonatomic, strong) NSData            *gifData;


### PR DESCRIPTION
I had to add this to make it work in a Swift project. I've tested that this doesn't break complication with a Obj-C project in latest Xcode.